### PR TITLE
Always show cargo.lock changes in code review

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Cargo.lock linguist-generated=false


### PR DESCRIPTION
## 💻 Description of Change(s) (w/ context)

This should instruct github that Cargo.lock isn't just generated content we don't care about, but a reviewable, important document.
