### PR TITLE
References #46.  Build that will create both amd64 and arm64 versions.

### DIFF
--- a/.github/workflows/02_rust_publish_images.yml
+++ b/.github/workflows/02_rust_publish_images.yml
@@ -1,5 +1,8 @@
 name: 02. Publish Rust Container Images # ginger
 
+env:
+  PLATFORMS: linux/amd64, linux/arm64
+
 on:
   push:
     # Publish semver tags as releases.
@@ -33,8 +36,13 @@ jobs:
       id-token: write
 
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+            platforms: ${{env.PLATFORMS}}
 
       - name: Checkout with LFS
         uses: actions/checkout@v4
@@ -74,6 +82,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+          flavor: |
+            latest=true
 
       - name: Build and Push Docker Image
         id: push


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)
Reviewers should look at diff and confirm changes.  Note that I also trigger to have it be the latest by the flavor attribute in the build.  I had to manually port over from [jtperry/ginger](https://github.com/jtperry/ginger)

Note that the qemu arm portion of the build can take an hour plus

### 🧠 Rationale Behind Change(s)
Users need to be able to use both arm (macos usually) and amd64 images.  

### 📝 Test Plan
Multiple runs on windows and mac.

### 📜 Documentation
No documentation needs to change

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [ ] Mention an issue number in the PR title?
- [ ] Update the version # in the build file?
- [ ] Create new and/or update relevant existing tests?
- [ ] Create or update relevant documentation and/or diagrams?
- [ ] Comment your code?
- [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
