### PR TITLE
Native container images

### DIFF
--- a/.github/workflows/02_rust_publish_images.yml
+++ b/.github/workflows/02_rust_publish_images.yml
@@ -1,5 +1,8 @@
 name: 02. Publish Rust Container Images # ginger
 
+env:
+  PLATFORMS: linux/amd64, linux/arm64
+
 on:
   push:
     # Publish semver tags as releases.
@@ -33,8 +36,13 @@ jobs:
       id-token: write
 
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+            platforms: ${{env.PLATFORMS}}
 
       - name: Checkout with LFS
         uses: actions/checkout@v4
@@ -74,6 +82,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+          flavor: |
+            latest=true
 
       - name: Build and Push Docker Image
         id: push

--- a/.github/workflows/02_rust_publish_images.yml
+++ b/.github/workflows/02_rust_publish_images.yml
@@ -89,6 +89,7 @@ jobs:
         id: push
         uses: docker/build-push-action@v6
         with:
+          platforms: ${{env.PLATFORMS}}
           context: .
           push: true
           provenance: mode=max


### PR DESCRIPTION
Fixes #46 

### 💻 Description of Change(s) (w/ context)
Changes necessary to generate an arm64 docker image of Ginger

### 🧠 Rationale Behind Change(s)
Customers have challenges running command line with out arm64 images when on apple silicone and without hacking bash scripts

### 📝 Test Plan
Tested in my own fork jtperry/ginger

### 📜 Documentation
What documentation did you add or update? 
Was the documentation appropriate for the scope of this change?

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [ ] Mention an issue number in the PR title?
- [ ] Update the version # in the build file?
- [ ] Create new and/or update relevant existing tests?
- [ ] Create or update relevant documentation and/or diagrams?
- [ ] Comment your code?
- [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
